### PR TITLE
add Terraform scripts for DynamoDB creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,9 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# Terraform
+*/**/terraform.tfstate
+*/**/terraform.tfstate*
+*/**/.terraform
+#*/**/configuration/*.tfvars

--- a/tools/Terraform/README.md
+++ b/tools/Terraform/README.md
@@ -1,0 +1,49 @@
+# Tools: DynamoDB - Terraform
+
+## Overview
+
+The following instructions will get you started with creating the relevant AWS DynamoDB tables for IdentityServer4.Contrib.AwsDynamoDB
+
+For further reading, see
+
+- Terraform Developer Documentation, https://www.terraform.io/docs/index.html
+- Terraform AWS Provider, https://www.terraform.io/docs/providers/aws/index.html
+- Terraform AWS Provider DynamoDB, https://www.terraform.io/docs/providers/aws/r/dynamodb_table.html
+
+## Installation
+
+### Download executable
+https://www.terraform.io/downloads.html
+
+### Docker Image
+https://hub.docker.com/r/hashicorp/terraform/
+
+## Usage
+### Initialize Infrastructure State
+```
+> ./terraform init
+```
+
+### Run Execution Plan
+```
+> ./terraform plan \
+    -var-file="./configuration/terraform.tfvars" \
+    -var-file="./configuration/jd-env.tfvars"
+```
+
+### Terraform Environment
+```
+> ./terraform apply \
+    -var-file="./configuration/terraform.tfvars" \
+    -var-file="./configuration/jd-env.tfvars"
+```
+
+### Destroy Environment
+```
+> ./terraform destroy \
+    -var-file="./configuration/terraform.tfvars" \
+    -var-file="./configuration/jd-env.tfvars"
+```
+
+## License
+MIT

--- a/tools/Terraform/configuration/development.tfvars
+++ b/tools/Terraform/configuration/development.tfvars
@@ -1,0 +1,4 @@
+#
+# Environment Input File
+#
+environment = "development"

--- a/tools/Terraform/configuration/production.tfvars
+++ b/tools/Terraform/configuration/production.tfvars
@@ -1,0 +1,4 @@
+#
+# Environment Input File
+#
+environment = "production"

--- a/tools/Terraform/configuration/terraform.tfvars
+++ b/tools/Terraform/configuration/terraform.tfvars
@@ -1,0 +1,6 @@
+#
+# Default Input Variables
+#
+aws_credentials_file = "~/.aws/credentials"
+aws_credentials_profile = "default"
+aws_region = "ap-southeast-2"

--- a/tools/Terraform/main.tf
+++ b/tools/Terraform/main.tf
@@ -1,0 +1,14 @@
+#
+# Entry Point
+#
+provider "aws" {
+    region = "${var.aws_region}"
+    shared_credentials_file = "${var.aws_credentials_file}"
+    profile = "${var.aws_credentials_profile}"
+}
+
+module "DynamoDB" {
+  source = "./modules/DynamoDB"
+  
+  prefix = "${var.environment}"
+}

--- a/tools/Terraform/modules/DynamoDB/main.tf
+++ b/tools/Terraform/modules/DynamoDB/main.tf
@@ -1,0 +1,149 @@
+#
+# Module: DynamoDB Table Creation
+#
+locals {
+    # <prefix>- or blank
+    name_prefix = "%{if var.prefix != ""}${var.prefix}-%{else}%{endif}"
+}
+
+#
+# Client Table
+#
+resource "aws_dynamodb_table" "Client" {
+    name = "${local.name_prefix}Client"
+    billing_mode = "PROVISIONED"
+    read_capacity = 5
+    write_capacity = 5
+    hash_key = "ClientId"
+    
+    attribute {
+        name = "ClientId"
+        type = "S"
+    }
+    attribute {
+        name = "JsonString"
+        type = "S"
+    }
+
+    global_secondary_index {
+        name = "JsonString-Index"
+        hash_key = "JsonString"
+        projection_type = "ALL"        
+        read_capacity = 5
+        write_capacity = 5
+    }
+}
+
+#
+# ApiResource Table
+#
+resource "aws_dynamodb_table" "ApiResource" {
+    name = "${local.name_prefix}ApiResource"
+    billing_mode = "PROVISIONED"
+    read_capacity = 5
+    write_capacity = 5
+    hash_key = "Name"
+    
+    attribute {
+        name = "Name"
+        type = "S"
+    }
+    attribute {
+        name = "JsonString"
+        type = "S"
+    }
+
+    global_secondary_index {
+        name = "JsonString-Index"
+        hash_key = "JsonString"
+        projection_type = "ALL"        
+        read_capacity = 5
+        write_capacity = 5
+    }
+}
+
+#
+# IdentityResource
+#
+resource "aws_dynamodb_table" "IdentityResource" {
+    name = "${local.name_prefix}IdentityResource"
+    billing_mode = "PROVISIONED"
+    read_capacity = 5
+    write_capacity = 5
+    hash_key = "Name"
+    
+    attribute {
+        name = "Name"
+        type = "S"
+    }
+    attribute {
+        name = "JsonString"
+        type = "S"
+    }
+
+    global_secondary_index {
+        name = "JsonString-Index"
+        hash_key = "JsonString"
+        projection_type = "ALL"        
+        read_capacity = 5
+        write_capacity = 5
+    }
+}
+
+#
+# PersistedGrant Table
+# NOTE: this table has TTL enbabled
+#
+resource "aws_dynamodb_table" "PersistedGrant" {
+    name = "${local.name_prefix}PersistedGrant"
+    billing_mode = "PROVISIONED"
+    read_capacity = 5
+    write_capacity = 5
+    hash_key = "Key"
+    
+    attribute {
+        name = "Key"
+        type = "S"
+    }
+    attribute {
+        name = "ClientId"
+        type = "S"
+    }
+    attribute {
+        name = "Subject"
+        type = "S"
+    }
+    attribute {
+        name = "Type"
+        type = "S"
+    }
+
+    global_secondary_index {
+        name = "ClientId-Index"
+        hash_key = "ClientId"
+        projection_type = "ALL"        
+        read_capacity = 5
+        write_capacity = 5
+    }
+
+    global_secondary_index {
+        name = "Subject-Index"
+        hash_key = "Subject"
+        projection_type = "ALL"        
+        read_capacity = 5
+        write_capacity = 5
+    }
+
+    global_secondary_index {
+        name = "Type-Index"
+        hash_key = "Type"
+        projection_type = "ALL"        
+        read_capacity = 5
+        write_capacity = 5
+    }
+
+    ttl {
+        attribute_name = "Expiration"
+        enabled = true
+    }
+}

--- a/tools/Terraform/modules/DynamoDB/variables.tf
+++ b/tools/Terraform/modules/DynamoDB/variables.tf
@@ -1,0 +1,6 @@
+#
+# Module: DynamoDB Table Creation Variables
+#
+variable "prefix" {
+  type="string"
+}

--- a/tools/Terraform/variables.tf
+++ b/tools/Terraform/variables.tf
@@ -1,0 +1,20 @@
+#
+# Variables
+#
+variable "environment" {
+  type = "string"
+  default = ""
+}
+
+variable "aws_region" {
+  type = "string"
+}
+
+variable "aws_credentials_file" {
+  type = "string"
+}
+
+variable "aws_credentials_profile" {
+  type = "string"
+  default = "default"
+}


### PR DESCRIPTION
An alternative to Python Boto3 scripts for creating the DynamoDB tables.